### PR TITLE
Add user info to context.user_info and set mock data for local authorization tokens

### DIFF
--- a/core/morph/api/auth.py
+++ b/core/morph/api/auth.py
@@ -1,14 +1,43 @@
+import json
+import os
+
 from fastapi import Header
+
+from morph.api.cloud.types import UserInfo
+from morph.api.context import request_context
+from morph.api.error import AuthError, ErrorCode, ErrorMessage
+from morph.task.utils.morph import find_project_root_dir
 
 
 async def auth(authorization: str = Header(default=None)) -> None:
-    # if not authorization.startswith("Bearer "):
-    #     raise AuthError(
-    #         ErrorCode.AuthError, ErrorMessage.AuthErrorMessage["notAuthorized"]
-    #     )
-    # token = authorization.split(" ")[1]
+    if authorization == "Bearer dummy":
+        # "dummy" is set when running in local
+        project_root = find_project_root_dir()
+        mock_json_path = f"{project_root}/.mock_user_context.json"
+        if not os.path.exists(mock_json_path):
+            request_context.set(
+                {
+                    "user": UserInfo(
+                        user_id="cea122ea-b240-49d7-ae7f-8b1e3d40dd8f",
+                        email="example@morph-data.io",
+                        username="sample",
+                        first_name="Sample",
+                        last_name="User",
+                        roles=["Admin"],
+                    ).model_dump()
+                }
+            )
+            return
+        try:
+            mock_json = json.load(open(mock_json_path))
+            request_context.set({"user": mock_json})
+            return
+        except Exception:
+            raise AuthError(
+                ErrorCode.AuthError, ErrorMessage.AuthErrorMessage["mockJsonInvalid"]
+            )
 
-    # TODO: required to verify api key and get user info
+    # TODO: deserialize token
     # user = UserInfo(
     #     username=response_json["user"]["username"],
     #     email=response_json["user"]["email"],
@@ -16,4 +45,3 @@ async def auth(authorization: str = Header(default=None)) -> None:
     #     last_name=response_json["user"]["lastName"],
     # )
     # request_context.set({"user": user.model_dump()})
-    pass

--- a/core/morph/api/auth.py
+++ b/core/morph/api/auth.py
@@ -20,9 +20,9 @@ async def auth(authorization: str = Header(default=None)) -> None:
                 {
                     "user": UserInfo(
                         user_id="cea122ea-b240-49d7-ae7f-8b1e3d40dd8f",
-                        email="example@morph-data.io",
-                        username="sample",
-                        first_name="Sample",
+                        email="mock_user@morph-data.io",
+                        username="mock_user",
+                        first_name="Mock",
                         last_name="User",
                         roles=["Admin"],
                     ).model_dump()

--- a/core/morph/api/cloud/types.py
+++ b/core/morph/api/cloud/types.py
@@ -7,10 +7,12 @@ from pydantic import BaseModel
 # User
 # ================================================
 class UserInfo(BaseModel):
+    user_id: str
     username: str
     email: str
     first_name: str
     last_name: str
+    roles: List[str]
 
 
 # ================================================

--- a/core/morph/api/error.py
+++ b/core/morph/api/error.py
@@ -43,6 +43,7 @@ class ErrorMessage:
     }
     AuthErrorMessage = {
         "notAuthorized": "Not authorized.",
+        "mockJsonInvalid": "Invalid mock json.",
     }
     FileErrorMessage = {
         "notFound": "File not found.",

--- a/core/morph/api/error.py
+++ b/core/morph/api/error.py
@@ -44,6 +44,7 @@ class ErrorMessage:
     AuthErrorMessage = {
         "notAuthorized": "Not authorized.",
         "mockJsonInvalid": "Invalid mock json.",
+        "tokenInvalid": "Invalid token.",
     }
     FileErrorMessage = {
         "notFound": "File not found.",


### PR DESCRIPTION
## Describe your changes
- add user_context mock data when jwt is not provided
- get user_context from <project_root>/.mock_user_context.json'
- decode jwt to get user_context

## GitHub Issue Link (if applicable)
none

## How I Tested These Changes
- run curl command to call api with each authorization token

## Additional context

