### PR TITLE
Enable poetry Interpreter in morph new Command

### DIFF
--- a/core/morph/task/new.py
+++ b/core/morph/task/new.py
@@ -137,7 +137,7 @@ class NewTask(BaseTask):
                 # Prepare the dependency argument
                 if self.is_development:
                     branch = self._get_current_git_branch() or "develop"
-                    dependency = f"git+https://github.com/morph-data/morph.git@{branch}#egg=morph-data"
+                    dependency = f"git+https://github.com/morph-data/morph.git@{branch}"
                 else:
                     dependency = (
                         f"morph-data=={morph_data_version}"
@@ -206,10 +206,7 @@ class NewTask(BaseTask):
                 cwd=self.original_dir,
                 text=True,
             ).strip()
-
-            if branch:
-                return branch
-            return None
+            return branch or None
         except (subprocess.CalledProcessError, FileNotFoundError):
             # Return None if Git command fails or Git is not installed
             click.echo(


### PR DESCRIPTION
## Describe your changes

Enabled the use of poetry as an interpreter during project initialization with the morph new command. This enhancement simplifies dependency management for new projects.

## GitHub Issue Link (if applicable)

## How I Tested These Changes

- Verified that executing the `morph new` command generates a pyproject.toml file, enabling project management with poetry.
- Confirmed that the results of the `morph deploy` command function as expected in the cloud environment.

## Additional context

Add any other context or screenshots.
