### PR TITLE
Fix Frontend Directory Lifecycle

### DIFF
--- a/core/morph/constants.py
+++ b/core/morph/constants.py
@@ -2,11 +2,18 @@ import os
 
 
 class MorphConstant:
-    # Directories
+    """Directories"""
+
     INIT_DIR = os.path.expanduser("~/.morph")
     TMP_MORPH_DIR = "/tmp/morph"
-    # Files
+
+    @staticmethod
+    def frontend_dir(project_root: str) -> str:
+        return os.path.join(project_root, ".morph", "frontend")
+
+    """ Files """
     MORPH_CRED_PATH = os.path.expanduser("~/.morph/credentials")
     MORPH_CONNECTION_PATH = os.path.expanduser("~/.morph/connections.yml")
-    # Others
+
+    """ Others """
     EXECUTABLE_EXTENSIONS = [".sql", ".py"]

--- a/core/morph/task/deploy.py
+++ b/core/morph/task/deploy.py
@@ -19,7 +19,7 @@ from morph.cli.flags import Flags
 from morph.config.project import load_project
 from morph.task.base import BaseTask
 from morph.task.utils.file_upload import FileWithProgress
-from morph.task.utils.morph import find_project_root_dir
+from morph.task.utils.morph import find_project_root_dir, initialize_frontend_dir
 
 
 class DeployTask(BaseTask):
@@ -79,11 +79,7 @@ class DeployTask(BaseTask):
             sys.exit(1)
 
         # Frontend and backend settings
-        self.frontend_template_dir = os.path.join(
-            Path(__file__).resolve().parents[1], "frontend", "template"
-        )
-        self.frontend_dir = os.path.join(self.project_root, ".morph/frontend")
-        self.dist_dir = os.path.join(self.frontend_dir, "dist")
+        self.frontend_dir = initialize_frontend_dir(self.project_root)
         self.backend_template_dir = os.path.join(Path(__file__).resolve().parents[2])
         self.backend_dir = os.path.join(self.project_root, ".morph/core")
 
@@ -328,14 +324,6 @@ class DeployTask(BaseTask):
     def _copy_and_build_source(self):
         click.echo(click.style("Building frontend...", fg="blue"))
         try:
-            # Copy the frontend template
-            if os.path.exists(self.frontend_dir):
-                shutil.rmtree(self.frontend_dir)  # Remove existing frontend directory
-            os.makedirs(self.frontend_dir, exist_ok=True)
-            shutil.copytree(
-                self.frontend_template_dir, self.frontend_dir, dirs_exist_ok=True
-            )
-
             # Run npm install and build
             subprocess.run(["npm", "install"], cwd=self.project_root, check=True)
             subprocess.run(["npm", "run", "build"], cwd=self.project_root, check=True)

--- a/core/morph/task/new.py
+++ b/core/morph/task/new.py
@@ -12,6 +12,7 @@ from morph.cli.flags import Flags
 from morph.config.project import default_initial_project, load_project, save_project
 from morph.constants import MorphConstant
 from morph.task.base import BaseTask
+from morph.task.utils.morph import initialize_frontend_dir
 from morph.task.utils.run_backend.state import MorphGlobalContext
 
 
@@ -30,6 +31,10 @@ class NewTask(BaseTask):
         if not os.path.exists(morph_dir):
             os.makedirs(morph_dir)
             click.echo(f"Created directory at {morph_dir}")
+
+        # Initialize the frontend directory
+        # Copy the frontend template to ~/.morph/frontend if it doesn't exist
+        initialize_frontend_dir(self.project_root)
 
     def run(self):
         click.echo("Creating new Morph project...")

--- a/core/morph/task/utils/morph.py
+++ b/core/morph/task/utils/morph.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import os
 import re
+import shutil
 import time
 from datetime import datetime
 from pathlib import Path
@@ -40,6 +41,23 @@ def find_project_root_dir(abs_filepath: Optional[str] = None) -> str:
     raise FileNotFoundError(
         "morph_project.yml not found in the current directory or any parent directories."
     )
+
+
+def initialize_frontend_dir(project_root: str) -> str:
+    """
+    Initialize the frontend directory by copying the template frontend directory to the project directory.
+    Does nothing if the frontend directory already exists.
+    @param project_root:
+    @return:
+    """
+    frontend_template_dir = os.path.join(
+        Path(__file__).resolve().parents[2], "frontend", "template"
+    )
+    frontend_dir = MorphConstant.frontend_dir(project_root)
+    if not os.path.exists(frontend_dir):
+        os.makedirs(frontend_dir, exist_ok=True)
+        shutil.copytree(frontend_template_dir, frontend_dir, dirs_exist_ok=True)
+    return frontend_dir
 
 
 class Resource(BaseModel):


### PR DESCRIPTION
## Describe your changes

This PR addresses handling fix for the frontend directory with the following updates:
- Changed the timing for creating the frontend directory from the template to the `morph new` command.
- Modified the `morph clean` command to ensure that the `~/.morph/frontend` directory is not deleted.

## GitHub Issue Link (if applicable)

## How I Tested These Changes

Verified that the following command works as expected:
- `morph new`
- `morph serve`
- `morph clean`
- `morph deploy`

## Additional context

Add any other context or screenshots.
