### PR TITLE
Fix Dockerfile Template

### DIFF
--- a/core/morph/include/Dockerfile
+++ b/core/morph/include/Dockerfile
@@ -1,12 +1,5 @@
-# Base image for AWS Lambda
-FROM public.ecr.aws/lambda/python:3.9
-
-RUN yum install -y \
-    postgresql-devel \
-    git \
-    gcc \
-    gcc-c++ && \
-    yum clean all
+# Base image for Morph Cloud
+FROM public.ecr.aws/i1l4z0u0/morph-cloud:python3.9
 
 # Set working directory
 WORKDIR /var/task

--- a/core/morph/include/Dockerfile
+++ b/core/morph/include/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /var/task
 
 # Install Python dependencies with poetry
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+RUN pip install --no-cache-dir -r requirements.txt --target "${MORPH_TASK_ROOT}"
 
 # Copy source code and dependencies
 COPY .morph/frontend/dist /var/task/.morph/frontend/dist


### PR DESCRIPTION
## Describe your changes

This PR introduces the new Dockerfile template for morph project:
- Using docker image for morph-cloud template
- Change docker env vars to fit morph-cloud syntax

## GitHub Issue Link (if applicable)

## How I Tested These Changes

Verified that the morph cloud project worked as expected after deploying a newly created morph local project.

## Additional context

Add any other context or screenshots.
