### PR TITLE
Removed deprecated params from morph meta object

### DIFF
--- a/core/morph/task/utils/run_backend/execution.py
+++ b/core/morph/task/utils/run_backend/execution.py
@@ -427,8 +427,6 @@ def _regist_sql_data_requirements(resource: MorphFunctionMetaObject) -> List[str
             function=resource.function,
             description=resource.description,
             title=resource.title,
-            schemas=resource.schemas,
-            terms=resource.terms,
             variables=resource.variables,
             data_requirements=load_data,
             output_paths=resource.output_paths,


### PR DESCRIPTION
## Describe your changes
fix: removed deprecated params from morph meta object

## GitHub Issue Link (if applicable)

## How I Tested These Changes

## Additional context

Add any other context or screenshots.
