### PR TITLE
Add Warning and Confirmation Prompt Before Overwriting Existing Profiles

### DIFF
--- a/core/morph/task/config.py
+++ b/core/morph/task/config.py
@@ -1,6 +1,7 @@
 import configparser
 import os
 import socket
+import sys
 
 import click
 
@@ -45,7 +46,7 @@ class ConfigTask(BaseTask):
                     fg="red",
                 )
             )
-            exit(1)
+            sys.exit(1)
         click.echo(click.style("✅ Verified", fg="green"))
 
         # Load existing file or create new one if it doesn't exist
@@ -54,11 +55,26 @@ class ConfigTask(BaseTask):
         if os.path.exists(cred_file):
             config.read(cred_file)
 
-        # Update the settings in the specific section
-        if not config.has_section(profile_name):
-            click.echo("Creating new credentials...")
+        # Warn user if profile already exists and prompt for overwrite
+        if config.has_section(profile_name):
+            warning_message = click.style(
+                f"Warning: Profile '{profile_name}' already exists. Overwrite?",
+                fg="yellow",
+            )
+            confirm = click.confirm(warning_message, default=False)
+            if not confirm:
+                click.echo(
+                    click.style(
+                        "Operation canceled. No credentials overwritten.",
+                        fg="red",
+                    )
+                )
+                sys.exit(1)
+            click.echo("Overwriting existing credentials...")
         else:
-            click.echo("Credentials already exist. Updating...")
+            click.echo("Creating new credentials...")
+
+        # Update the settings in the specific section
         config[profile_name] = {
             "api_key": api_key,
         }
@@ -70,7 +86,7 @@ class ConfigTask(BaseTask):
         click.echo(f"Credentials saved to {cred_file}")
         click.echo(
             click.style(
-                f"✅ Successfully setup! This profile can be access by profile name '{profile_name}' via morph cli.",
+                f"✅ Successfully setup! This profile can be accessed by profile name '{profile_name}' via morph cli.",
                 fg="green",
             )
         )


### PR DESCRIPTION
## Describe your changes
This PR introduces the following features:
- Warning Message for Existing Profiles: Implemented a yellow-colored warning message using `click.style` to inform users when a profile already exists.
- Import `sys` Module: Added `import sys` to utilize `sys.exit(1)` for exiting the program more explicitly.

## GitHub Issue Link (if applicable)

## How I Tested These Changes

#### With or Without `--profile` Option:
- Creating a New Profile: Ran the `morph config` command with a new `--profile` name and verified that the profile was created successfully.
- Overwriting an Existing Profile: Ran the `morph config` command with an existing `--profile` name, confirmed that the yellow warning message appeared, and tested both overwriting (y) and canceling (N) the operation.

## Additional context

Add any other context or screenshots.
