### PR TITLE
fix: Force light mode to prevent unintended dark mode in hosted envir…

### DIFF
--- a/core/morph/api/templates/index.html
+++ b/core/morph/api/templates/index.html
@@ -18,6 +18,11 @@
     {% endif %}
 
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        darkMode: "class",
+      };
+    </script>
   </head>
   <body>
     {% inertia_body %}


### PR DESCRIPTION
Describe your changes
- Forced light mode to prevent unintended dark mode when hosted in a cloud environment.

GitHub Issue Link (if applicable)

How I Tested These Changes
Ran morph deploy and confirmed that the UI remains in light mode.

Additional context

<img width="467" alt="スクリーンショット 2025-01-30 17 23 55" src="https://github.com/user-attachments/assets/94fb2648-fa68-4e20-b9a8-6bfcace0d410" />
