### PR TITLE
hotfix: pyproject.toml initialization

### DIFF
--- a/core/morph/task/new.py
+++ b/core/morph/task/new.py
@@ -170,7 +170,7 @@ class NewTask(BaseTask):
                     )
                 else:
                     if morph_data_version:
-                        morph_data_dep = f"morph-data = {morph_data_version}"
+                        morph_data_dep = f'morph-data = "{morph_data_version}"'
                     else:
                         morph_data_dep = "morph-data"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "morph-data"
-version = "0.1.3"
+version = "0.1.4"
 description = "Morph is a python-centric full-stack framework for building and deploying data apps."
 authors = ["Morph <contact@morphdb.io>"]
 packages = [


### PR DESCRIPTION
## Describe your changes

- fix pyproject.toml initialization

## GitHub Issue Link (if applicable)

## How I Tested These Changes

- run `morph new` locally

## Additional context

Currently, pyproject.toml generated by `morph run` misses `"` for morph-data package.

![image](https://github.com/user-attachments/assets/2e88d6ed-b4f9-4369-8ca9-ee069f82c959)


