### PR TITLE
make stream handle string

### DIFF
--- a/core/morph/task/utils/run_backend/output.py
+++ b/core/morph/task/utils/run_backend/output.py
@@ -230,7 +230,10 @@ data_lock = threading.Lock()
 
 
 def _dump_and_append_chunk(chunk: Any, data: List[Dict[str, Any]]) -> Any:
-    dumped_chunk = chunk.model_dump()
+    if isinstance(chunk, MorphChatStreamChunk):
+        dumped_chunk = chunk.model_dump()
+    else:
+        dumped_chunk = {"text": str(chunk), "content": None}
     with data_lock:
         data.append(dumped_chunk)
     return dumped_chunk


### PR DESCRIPTION
## Describe your changes

- make it possible to handle `yield [string]` as a stream response.

## GitHub Issue Link (if applicable)

## How I Tested These Changes

Tested locally by morph serve & the below code.

```
@morph.func
async def langchain_chat(context: MorphGlobalContext):
    llm = ChatOpenAI(model="gpt-4o")
    messages = [HumanMessage(context.vars["prompt"])]
    for token in llm.stream(messages):
        yield token.content

```

## Additional context

Add any other context or screenshots.
