### PR TITLE
Fix: Ensure poetry install and uv sync Runs Properly on morph new Task

### DIFF
--- a/core/morph/task/new.py
+++ b/core/morph/task/new.py
@@ -184,6 +184,10 @@ class NewTask(BaseTask):
                 pyproject_path = Path(self.project_root) / "pyproject.toml"
                 pyproject_path.write_text(pyproject_content, encoding="utf-8")
 
+                # Run 'poetry install' to install the dependencies
+                click.echo(click.style("Running 'poetry install'...", fg="blue"))
+                subprocess.run(["poetry", "install"], cwd=self.project_root, check=True)
+
                 click.echo(
                     click.style(
                         "Added 'morph-data' to pyproject.toml with 'morph-data'.",

--- a/core/morph/task/new.py
+++ b/core/morph/task/new.py
@@ -190,7 +190,7 @@ class NewTask(BaseTask):
 
                 click.echo(
                     click.style(
-                        "Added 'morph-data' to pyproject.toml with 'morph-data'.",
+                        "Poetry initialized with 'morph-data' as a dependency.",
                         fg="green",
                     )
                 )
@@ -222,9 +222,13 @@ class NewTask(BaseTask):
                 pyproject_path = Path(self.project_root) / "pyproject.toml"
                 pyproject_path.write_text(pyproject_content, encoding="utf-8")
 
+                # Run 'uv sync' to install dependencies
+                click.echo(click.style("Running 'uv sync'...", fg="blue"))
+                subprocess.run(["uv", "sync"], cwd=self.project_root, check=True)
+
                 click.echo(
                     click.style(
-                        "Added 'morph-data' to pyproject.toml with 'morph-data'.",
+                        "uv initialized with 'morph-data' as a dependency.",
                         fg="green",
                     )
                 )


### PR DESCRIPTION
## Describe your changes

This PR fixes an issue where `poetry install` or `uv sync` was not being executed after running the `morph new` command, which led to a build error if a user tried to deploy a project without installing dependencies.

The following changes have been made:

 - Added a subprocess call to run `poetry install` or `uv sync` after generating the `pyproject.toml` file.
 - Created an `__init__.py` file in `starter_template` to ensure `poetry install` or `uv sync` works correctly.

## GitHub Issue Link (if applicable)

None.

## How I Tested These Changes

Ensure that the following steps performed as expected: 
 - Ran morph new to generate a new project.
 - Verified that `poetry.lock` or `uv.lock` was created successfully.
 - Confirmed that poetry install ran without issues in the correct directory.
 - Ensured that the project could be pushed to GitHub, linked to a project, built, deployed, and executed via Lambda.

## Additional Context

None.