### PR TITLE
change logic for checking use_custom_dockerfile

### DIFF
--- a/core/morph/config/project.py
+++ b/core/morph/config/project.py
@@ -162,13 +162,15 @@ def dump_project_yaml(project: MorphProject) -> str:
         deployment_provider = "aws"
 
     return f"""
-# Cloud Settings
-profile: {project.profile} # Defined in the Profile Section in `~/.morph/credentials`
-project_id: {project.project_id or "null"}
+version: 1
 
 # Framework Settings
 default_connection: {project.default_connection}
 source_paths:{source_paths}
+
+# Cloud Settings
+# profile: {project.profile} # Defined in the Profile Section in `~/.morph/credentials`
+# project_id: {project.project_id or "null"}
 
 # Build Settings
 build:

--- a/core/morph/config/project.py
+++ b/core/morph/config/project.py
@@ -14,7 +14,6 @@ from morph.task.utils.morph import find_project_root_dir
 
 
 class BuildConfig(BaseModel):
-    use_custom_dockerfile: bool = False
     runtime: Optional[str] = None
     framework: Optional[str] = "morph"
     package_manager: Optional[str] = None
@@ -101,7 +100,6 @@ def dump_project_yaml(project: MorphProject) -> str:
     source_paths = "\n- ".join([""] + project.source_paths)
 
     # Default values
-    build_use_custom_dockerfile = "false"
     build_runtime = ""
     build_framework = ""
     build_package_manager = ""
@@ -120,10 +118,6 @@ def dump_project_yaml(project: MorphProject) -> str:
 
     # Set values if build exists
     if project.build:
-        if project.build.use_custom_dockerfile is not None:
-            build_use_custom_dockerfile = str(
-                project.build.use_custom_dockerfile
-            ).lower()
         if project.build.runtime:
             build_runtime = project.build.runtime or ""
         if project.build.framework:
@@ -178,13 +172,12 @@ source_paths:{source_paths}
 
 # Build Settings
 build:
-    use_custom_dockerfile: {build_use_custom_dockerfile}
-    # These settings are required when use_custom_dockerfile is false
+    # These settings are required when there is no Dockerfile in the project root.
     # They define the environment in which the project will be built
     runtime: {build_runtime} # python3.9, python3.10, python3.11, python3.12
     framework: {build_framework}
     package_manager: {build_package_manager} # pip, poetry, uv
-    # These settings are required when use_custom_dockerfile is true
+    # These settings are required when there is a Dockerfile in the project root.
     # They define how the Docker image will be built
     # context: {build_context}
     # build_args:{build_args_str}

--- a/core/morph/config/project.py
+++ b/core/morph/config/project.py
@@ -162,7 +162,7 @@ def dump_project_yaml(project: MorphProject) -> str:
         deployment_provider = "aws"
 
     return f"""
-version: 1
+version: '1'
 
 # Framework Settings
 default_connection: {project.default_connection}

--- a/core/morph/task/deploy.py
+++ b/core/morph/task/deploy.py
@@ -50,12 +50,9 @@ class DeployTask(BaseTask):
         self.package_manager = self.project.package_manager
 
         # Check Dockerfile existence
-        self.dockerfile = os.path.join(self.project_root, "Dockerfile")
-        if self.project.build is not None and self.project.build.use_custom_dockerfile:
-            if not os.path.exists(self.dockerfile):
-                click.echo(click.style(f"Error: {self.dockerfile} not found", fg="red"))
-                sys.exit(1)
-        else:
+        self.dockerfile_path = os.path.join(self.project_root, "Dockerfile")
+        self.use_custom_dockerfile = os.path.exists(self.dockerfile_path)
+        if self.use_custom_dockerfile:
             provider = "aws"
             if (
                 self.project.deployment is not None
@@ -73,7 +70,7 @@ class DeployTask(BaseTask):
                     self.project.build.package_manager,
                     self.project.build.runtime,
                 )
-            with open(self.dockerfile, "w") as f:
+            with open(self.dockerfile_path, "w") as f:
                 f.write(dockerfile)
             dockerignore_path = os.path.join(self.project_root, ".dockerignore")
             with open(dockerignore_path, "w") as f:
@@ -440,7 +437,7 @@ class DeployTask(BaseTask):
             "-t",
             self.image_name,
             "-f",
-            self.dockerfile,
+            self.dockerfile_path,
             self.project_root,
         ]
         if self.no_cache:


### PR DESCRIPTION
## Describe your changes

To keep older version working,
1. removed `use_custom_dockerfile` key from morph_project.yml
2. changed the logic for using custom dockerfile with the following rules
- use template dockerfile for each framework when there is no dockerfile in the project root.
- use user's custom dockerfile when there is a dockerfile in the project root.